### PR TITLE
BILL-71 - change tests to avoid testing whole app

### DIFF
--- a/src/controllers/claimStartController.js
+++ b/src/controllers/claimStartController.js
@@ -1,3 +1,4 @@
+import { getUrl } from "../routes/urls";
 import {
   isValidLawCategory,
   getLawCategories,
@@ -58,7 +59,7 @@ export function postClaimStartPage(req, res) {
     req.session.data.startDate = date;
     req.session.data.lawCategory = category;
 
-    res.redirect("/fee-entry");
+    res.redirect(getUrl["feeEntry"]);
   } catch (ex) {
     console.error(
       "Error occurred during POST %s: %s",

--- a/src/controllers/feeEntryController.js
+++ b/src/controllers/feeEntryController.js
@@ -27,13 +27,11 @@ export function showFeeEntryPage(req, res) {
  */
 export async function postFeeEntryPage(req, res) {
   try {
-    console.log("FEE " + req.body.fee)
+    console.log("FEE " + req.body.fee);
     const fee = req.body.fee;
     if (fee == null || isNaN(fee)) {
       throw new Error("Fee not defined");
     }
-
-
 
     const response = await req.axiosMiddleware.post("/fees/" + fee);
 

--- a/src/controllers/feeEntryController.js
+++ b/src/controllers/feeEntryController.js
@@ -1,3 +1,4 @@
+import { getUrl } from "../routes/urls";
 import { getSessionData } from "../utils";
 
 /**
@@ -26,19 +27,22 @@ export function showFeeEntryPage(req, res) {
  */
 export async function postFeeEntryPage(req, res) {
   try {
+    console.log("FEE " + req.body.fee)
     const fee = req.body.fee;
-
     if (fee == null || isNaN(fee)) {
       throw new Error("Fee not defined");
     }
 
+
+
     const response = await req.axiosMiddleware.post("/fees/" + fee);
+
     const number = response.data;
 
     // Save this so it can be displayed on the result page
     req.session.data.result = number;
 
-    res.redirect("/result");
+    res.redirect(getUrl("result"));
   } catch (ex) {
     console.error("Error occurred during POST /fee-entry: {}", ex.message);
 

--- a/src/controllers/feeEntryController.test.js
+++ b/src/controllers/feeEntryController.test.js
@@ -1,165 +1,148 @@
 import request from "supertest";
 import express from "express";
-import { nunjucksSetup } from "../utils";
+import { axiosMiddleware, nunjucksSetup } from "../utils";
 import indexRouter from "../routes/index";
+import { postFeeEntryPage, showFeeEntryPage } from "./feeEntryController";
 
-describe("GET /fee-entry", () => {
-  let app;
-  let mockSession = {};
-  const csrfMock = jest.fn();
-  app = express();
+import { getSessionData } from "../utils";
+import { getUrl } from "../routes/urls";
+jest.mock("../utils/sessionHelper");
+
+describe("showFeeEntryPage", () => {
+
+  let req = {
+    csrfToken: jest.fn()
+  }
+  let res = {
+    render: jest.fn()
+  }
 
   beforeEach(() => {
-    mockSession = {
-      data: {},
-    };
+    getSessionData.mockReturnValue({});
 
-    // Mock the middleware
-    app.use((req, _res, next) => {
-      req.csrfToken = csrfMock;
-      req.session = mockSession;
-
-      next();
-    });
-    app.use("/", indexRouter);
-
-    // Would be nice to mock the nunjucks rendering but not managed to figure that bit out
-    nunjucksSetup(app);
-  });
+    req.csrfToken.mockReturnValue("mocked-csrf-token");
+  })
 
   it("should render fee entry page", async () => {
-    csrfMock.mockReturnValue("mocked-csrf-token");
-    const response = await request(app)
-      .get("/fee-entry")
-      .expect("Content-Type", /html/)
-      .expect(200);
 
-    expect(response.text).toContain("Enter a number");
+    showFeeEntryPage(req, res);
+
+    expect(res.render).toHaveBeenCalledWith("main/feeEntry", {
+      csrfToken: "mocked-csrf-token"
+    })
   });
 
   it("should render error page if fails to load page", async () => {
-    csrfMock.mockImplementation(() => {
+    req.csrfToken.mockImplementation(() => {
       throw new Error("token problems");
     });
 
-    const response = await request(app)
-      .get("/fee-entry")
-      .expect("Content-Type", /html/)
-      .expect(200);
+    showFeeEntryPage(req, res);
 
-    expect(response.text).toContain("An error occurred");
+    expect(res.render).toHaveBeenCalledWith("main/error", {
+      "error": "An error occurred.",
+      "status": "An error occurred"
+    })
   });
 
   it("should render error page if no session data", async () => {
-    mockSession = {};
+        getSessionData.mockImplementation(() => { throw new Error("No session data found") })
 
-    const response = await request(app)
-      .get("/fee-entry")
-      .expect("Content-Type", /html/)
-      .expect(200);
+        showFeeEntryPage(req, res);
 
-    expect(response.text).toContain("An error occurred");
+        expect(res.render).toHaveBeenCalledWith("main/error", {
+            "error": "An error occurred.",
+            "status": "An error occurred"
+        })
   });
 });
 
 describe("POST /fee-entry", () => {
-  let app;
-  let mockSession = {};
-  let formData;
-  const apiMock = jest.fn();
-  app = express();
+  let sessionData = {}
+
+  let req = {
+      session: {
+          data: sessionData
+      },
+      body: {},
+      axiosMiddleware: {
+        post: jest.fn()
+      }
+  }
+  let res = {
+      render: jest.fn(),
+      redirect: jest.fn()
+  }
 
   beforeEach(() => {
-    formData = 123;
-    mockSession = {};
-    apiMock.mockReset();
-
-    // Mock the middleware
-    app.use((req, _res, next) => {
-      mockSession = {
-        data: {},
-      };
-
-      // Make sure it exists
-      req.axiosMiddleware = req.axiosMiddleware || {};
-      req.axiosMiddleware.post = apiMock;
-      req.session = mockSession;
-
-      req.body = {
-        fee: formData,
-      };
-
-      next();
-    });
-    app.use("/", indexRouter);
-
-    // Would be nice to mock the nunjucks rendering but not managed to figure that bit out
-    nunjucksSetup(app);
+   req.body.fee = "1234.56"
   });
 
+  afterEach(() => {
+    sessionData = {}
+    req.body = {}
+})
+
   it("should redirect to result page if successful call service", async () => {
-    apiMock.mockReturnValue({
+    req.axiosMiddleware.post.mockResolvedValue({
       status: 200,
       data: "236.00",
     });
 
-    await request(app)
-      .post("/fee-entry")
-      .expect(302)
-      .expect("Location", "/result");
+    await postFeeEntryPage(req, res)
 
+   expect(res.redirect).toHaveBeenCalledWith(getUrl("result"))
+    
     // Save value so result page can load it
-    expect(mockSession.data.result).toEqual("236.00");
-
-    expect(apiMock).toHaveBeenCalledWith("/fees/123");
+    expect(sessionData.result).toEqual("236.00");
+    expect(req.axiosMiddleware.post).toHaveBeenCalledWith("/fees/1234.56");
   });
 
   describe("should error", () => {
     it("when api call fails", async () => {
-      apiMock.mockImplementation(() => {
+      req.axiosMiddleware.post.mockImplementation(() => {
         throw new Error("API connection issue");
       });
 
-      const response = await request(app)
-        .post("/fee-entry")
-        .expect("Content-Type", /html/)
-        .expect(200);
+      await postFeeEntryPage(req, res)
 
-      expect(response.text).toContain("An error occurred");
+      expect(res.render).toHaveBeenCalledWith("main/error", {
+        "error": "An error occurred posting the answer.",
+        "status": "An error occurred"
+    })
 
-      expect(mockSession.data.result).toBeUndefined();
-
-      expect(apiMock).toHaveBeenCalledWith("/fees/123");
+      expect(sessionData.result).toBeUndefined();
+      expect(req.axiosMiddleware.post).toHaveBeenCalledWith("/fees/1234.56");
     });
 
     it("when data from form is missing", async () => {
-      formData = null;
+      req.body.fee = null;
 
-      const response = await request(app)
-        .post("/fee-entry")
-        .expect("Content-Type", /html/)
-        .expect(200);
+      await postFeeEntryPage(req, res)
 
-      expect(response.text).toContain("An error occurred");
+      expect(res.render).toHaveBeenCalledWith("main/error", {
+        "error": "An error occurred posting the answer.",
+        "status": "An error occurred"
+    })
 
-      expect(mockSession.data.result).toBeUndefined();
-
-      expect(apiMock).toHaveBeenCalledTimes(0);
+      expect(sessionData.result).toBeUndefined();
+      expect(req.axiosMiddleware.post).toHaveBeenCalledTimes(0);
     });
 
     it("when data from form is not the right type", async () => {
-      formData = "hello";
 
-      const response = await request(app)
-        .post("/fee-entry")
-        .expect("Content-Type", /html/)
-        .expect(200);
+      req.body.fee = "hello";
 
-      expect(response.text).toContain("An error occurred");
+      await postFeeEntryPage(req, res)
 
-      expect(mockSession.data.result).toBeUndefined();
+      expect(res.render).toHaveBeenCalledWith("main/error", {
+        "error": "An error occurred posting the answer.",
+        "status": "An error occurred"
+    })
 
-      expect(apiMock).toHaveBeenCalledTimes(0);
+      expect(sessionData.result).toBeUndefined();
+      expect(req.axiosMiddleware.post).toHaveBeenCalledTimes(0);
+
     });
   });
 });

--- a/src/controllers/feeEntryController.test.js
+++ b/src/controllers/feeEntryController.test.js
@@ -1,7 +1,3 @@
-import request from "supertest";
-import express from "express";
-import { axiosMiddleware, nunjucksSetup } from "../utils";
-import indexRouter from "../routes/index";
 import { postFeeEntryPage, showFeeEntryPage } from "./feeEntryController";
 
 import { getSessionData } from "../utils";
@@ -9,27 +5,25 @@ import { getUrl } from "../routes/urls";
 jest.mock("../utils/sessionHelper");
 
 describe("showFeeEntryPage", () => {
-
   let req = {
-    csrfToken: jest.fn()
-  }
+    csrfToken: jest.fn(),
+  };
   let res = {
-    render: jest.fn()
-  }
+    render: jest.fn(),
+  };
 
   beforeEach(() => {
     getSessionData.mockReturnValue({});
 
     req.csrfToken.mockReturnValue("mocked-csrf-token");
-  })
+  });
 
   it("should render fee entry page", async () => {
-
     showFeeEntryPage(req, res);
 
     expect(res.render).toHaveBeenCalledWith("main/feeEntry", {
-      csrfToken: "mocked-csrf-token"
-    })
+      csrfToken: "mocked-csrf-token",
+    });
   });
 
   it("should render error page if fails to load page", async () => {
@@ -40,48 +34,50 @@ describe("showFeeEntryPage", () => {
     showFeeEntryPage(req, res);
 
     expect(res.render).toHaveBeenCalledWith("main/error", {
-      "error": "An error occurred.",
-      "status": "An error occurred"
-    })
+      error: "An error occurred.",
+      status: "An error occurred",
+    });
   });
 
   it("should render error page if no session data", async () => {
-        getSessionData.mockImplementation(() => { throw new Error("No session data found") })
+    getSessionData.mockImplementation(() => {
+      throw new Error("No session data found");
+    });
 
-        showFeeEntryPage(req, res);
+    showFeeEntryPage(req, res);
 
-        expect(res.render).toHaveBeenCalledWith("main/error", {
-            "error": "An error occurred.",
-            "status": "An error occurred"
-        })
+    expect(res.render).toHaveBeenCalledWith("main/error", {
+      error: "An error occurred.",
+      status: "An error occurred",
+    });
   });
 });
 
 describe("POST /fee-entry", () => {
-  let sessionData = {}
+  let sessionData = {};
 
   let req = {
-      session: {
-          data: sessionData
-      },
-      body: {},
-      axiosMiddleware: {
-        post: jest.fn()
-      }
-  }
+    session: {
+      data: sessionData,
+    },
+    body: {},
+    axiosMiddleware: {
+      post: jest.fn(),
+    },
+  };
   let res = {
-      render: jest.fn(),
-      redirect: jest.fn()
-  }
+    render: jest.fn(),
+    redirect: jest.fn(),
+  };
 
   beforeEach(() => {
-   req.body.fee = "1234.56"
+    req.body.fee = "1234.56";
   });
 
   afterEach(() => {
-    sessionData = {}
-    req.body = {}
-})
+    sessionData = {};
+    req.body = {};
+  });
 
   it("should redirect to result page if successful call service", async () => {
     req.axiosMiddleware.post.mockResolvedValue({
@@ -89,10 +85,10 @@ describe("POST /fee-entry", () => {
       data: "236.00",
     });
 
-    await postFeeEntryPage(req, res)
+    await postFeeEntryPage(req, res);
 
-   expect(res.redirect).toHaveBeenCalledWith(getUrl("result"))
-    
+    expect(res.redirect).toHaveBeenCalledWith(getUrl("result"));
+
     // Save value so result page can load it
     expect(sessionData.result).toEqual("236.00");
     expect(req.axiosMiddleware.post).toHaveBeenCalledWith("/fees/1234.56");
@@ -104,12 +100,12 @@ describe("POST /fee-entry", () => {
         throw new Error("API connection issue");
       });
 
-      await postFeeEntryPage(req, res)
+      await postFeeEntryPage(req, res);
 
       expect(res.render).toHaveBeenCalledWith("main/error", {
-        "error": "An error occurred posting the answer.",
-        "status": "An error occurred"
-    })
+        error: "An error occurred posting the answer.",
+        status: "An error occurred",
+      });
 
       expect(sessionData.result).toBeUndefined();
       expect(req.axiosMiddleware.post).toHaveBeenCalledWith("/fees/1234.56");
@@ -118,31 +114,29 @@ describe("POST /fee-entry", () => {
     it("when data from form is missing", async () => {
       req.body.fee = null;
 
-      await postFeeEntryPage(req, res)
+      await postFeeEntryPage(req, res);
 
       expect(res.render).toHaveBeenCalledWith("main/error", {
-        "error": "An error occurred posting the answer.",
-        "status": "An error occurred"
-    })
+        error: "An error occurred posting the answer.",
+        status: "An error occurred",
+      });
 
       expect(sessionData.result).toBeUndefined();
       expect(req.axiosMiddleware.post).toHaveBeenCalledTimes(0);
     });
 
     it("when data from form is not the right type", async () => {
-
       req.body.fee = "hello";
 
-      await postFeeEntryPage(req, res)
+      await postFeeEntryPage(req, res);
 
       expect(res.render).toHaveBeenCalledWith("main/error", {
-        "error": "An error occurred posting the answer.",
-        "status": "An error occurred"
-    })
+        error: "An error occurred posting the answer.",
+        status: "An error occurred",
+      });
 
       expect(sessionData.result).toBeUndefined();
       expect(req.axiosMiddleware.post).toHaveBeenCalledTimes(0);
-
     });
   });
 });

--- a/src/routes/urls.js
+++ b/src/routes/urls.js
@@ -1,6 +1,8 @@
 // To make it change urls easier during this early stage of the project
 const urls = {
   claimStart: "claim-start",
+  feeEntry: "fee-entry",
+  result: "result"
 };
 
 /**

--- a/src/routes/urls.js
+++ b/src/routes/urls.js
@@ -2,7 +2,7 @@
 const urls = {
   claimStart: "claim-start",
   feeEntry: "fee-entry",
-  result: "result"
+  result: "result",
 };
 
 /**


### PR DESCRIPTION
Previously controller tests were spinning up an app and testing this. Rewrite these tests so they actually behave as unit tests.